### PR TITLE
Update 02_joins.md

### DIFF
--- a/exercises/02_joins.md
+++ b/exercises/02_joins.md
@@ -48,7 +48,7 @@ Dodatkowe informacje:
 ---
 
 21. Oblicz łączną kwotę zapłaconą przez każdego z użytkowników
-22. Oblicz łączną kwotę, który każdy użytkownik powinien był zapłacić
+22. Oblicz łączną kwotę, którą każdy użytkownik powinien był zapłacić
 
 ~~23. Podaj listę użytkowników zalegających z opłatami~~
 


### PR DESCRIPTION
Błąd gramatyczny, tzw. literówka w zadania 22, zamiast poprawnego słowa "którą" było niepoprawne sformułowane słowo "który".